### PR TITLE
Added Condition: timer [not] running

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,11 +4,11 @@ var variableManager = require('./lib/variablemanagement/variablemanagement.js');
 var util = require('./lib/util/util.js');
 
 var autoCompleteActions = require('./lib/autocomplete/actions.js');
-//var autoCompleteConditions = require('./lib/autocomplete/conditions.js');
+var autoCompleteConditions = require('./lib/autocomplete/conditions.js');
 var autoCompleteTriggers = require('./lib/autocomplete/triggers.js');
 
 var flowActions = require('./lib/flow/actions.js');
-//var flowConditions = require('./lib/flow/conditions.js');
+var flowConditions = require('./lib/flow/conditions.js');
 //var flowTriggers = require('./lib/flow/triggers.js');
 
 var self = {
@@ -17,11 +17,11 @@ var self = {
 	variableManager.init();
 
 	autoCompleteActions.createAutocompleteActions();
-        //autoCompleteConditions.createAutocompleteConditions();
-        autoCompleteTriggers.createAutocompleteTriggers();
+    autoCompleteConditions.createAutocompleteConditions();
+    autoCompleteTriggers.createAutocompleteTriggers();
 	
 	flowActions.createActions();
-	//flowConditions.createConditions();
+	flowConditions.createConditions();
 	//flowTriggers.createTriggers();
 
         Homey.manager('flow').on('trigger.countdown_to_zero', function (callback,args,state) {

--- a/app.json
+++ b/app.json
@@ -49,6 +49,23 @@
        }
        ],
        "conditions": [
+      {
+        "id": "variable_less_than",
+        "title": {
+          "en": "timer !{{not|}} running",
+          "nl": "Zandloper loopt !{{niet|}}"
+        },
+        "args": [
+          {
+            "name": "variable",
+            "type": "autocomplete",
+            "placeholder": {
+              "en": "name", 
+			  "nl": "naam"
+            }
+          }
+        ]
+      }	   
        ],
        "actions": [
        {
@@ -63,7 +80,8 @@
             "name": "variable",
             "type": "autocomplete",
             "placeholder": {
-              "en": "name"
+              "en": "name", 
+			  "nl": "naam"
             }
           },
           {
@@ -91,7 +109,7 @@
             "placeholder": 
               {
               "en": "name",
-	      "nl": "naam"
+			  "nl": "naam"
               }
            }
          ]

--- a/lib/flow/conditions.js
+++ b/lib/flow/conditions.js
@@ -61,7 +61,7 @@ exports.createConditions = function (variables) {
     Homey.manager('flow').on('condition.variable_less_than', function (callback, args) {
         if (args.variable) {
             var variable = variableManager.getVariable(args.variable.name);
-            if (variable && variable.value < args.value) {
+            if (variable && variable.value < 1 ) {
                 Homey.log('variable_less_than');
                 callback(null, true);
                 return;


### PR DESCRIPTION
Added Condition Flow Card: timer [not] running

Hi, 
I was thinking about a "Debouncer" using your Countdown disabling and enabling flows:
https://forum.athom.com/discussion/comment/22576/#Comment_22576 

Is it possible to create a  Condition Card/ Condition  "Countdown [NOT] running"
This saves a flow in the example like above. 
(lucky you didn't remove the code, maybe time to cleanup soon ;-) )

(sory, just my first GitHub experience and Pull Req. ;-)  still learning!)