### PR TITLE
Fix date to human readable format in grid

### DIFF
--- a/lib/variablemanagement/variablemanagement.js
+++ b/lib/variablemanagement/variablemanagement.js
@@ -23,7 +23,7 @@ module.exports = {
                 if (!newvariables) {
                     newvariables = [];
                 }
-            
+
                 //Homey.log('-----Var Changed-----');
                 //Homey.log(newvariable);
                 //Homey.log('---------------------');
@@ -61,7 +61,7 @@ module.exports = {
             type: type,
             hasInsights: oldvariable.hasInsights,
             remove: oldvariable.remove,
-            lastChanged: setdate 
+            lastChanged: setdate
         }
         variables.unshift(newvariable);
 
@@ -85,14 +85,7 @@ function logExists(variableName) {
 
 
 function getShortDate() {
-    now = new Date();
-    year = "" + now.getFullYear();
-    month = "" + (now.getMonth() + 1); if (month.length == 1) { month = "0" + month; }
-    day = "" + now.getDate(); if (day.length == 1) { day = "0" + day; }
-    hour = "" + now.getHours(); if (hour.length == 1) { hour = "0" + hour; }
-    minute = "" + now.getMinutes(); if (minute.length == 1) { minute = "0" + minute; }
-    second = "" + now.getSeconds(); if (second.length == 1) { second = "0" + second; }
-    return year + "-" + month + "-" + day + " " + hour + ":" + minute + ":" + second;
+    return new Date().toISOString();
 }
 
 function getvariables() {

--- a/settings/index.html
+++ b/settings/index.html
@@ -51,7 +51,7 @@
             <thead>
                 <tr>
                     <th st-sort="name">Name</th>
-                    <th st-sort="type">Last action</th>
+                    <th st-sort="lastChanged" st-sort-default="reverse">Last action</th>
                     <th st-sort="value">Remaining seconds</th>
                     <th></th>
                 </tr>
@@ -77,7 +77,7 @@
 <script type="text/ng-template" id="display">
         <td>{{variable.name}}</td>
         <!--<td>{{variable.type}}</td>-->
-        <td>{{variable.lastChanged}}</td>
+        <td>{{variable.lastChanged | date:'yyyy-MM-dd HH:mm:ss'}}</td>
         <!--<td><input type='checkbox' disabled ng-model='variable.hasInsights' /></td>-->
 
         <td>{{variable.value}}</td>
@@ -89,7 +89,7 @@
 
 <script type="text/ng-template" id="edit">
         <td>{{vm.selected.name}}</td>
-        <td>{{variable.lastChanged}}</td>
+        <td>{{variable.lastChanged | date:'yyyy-MM-dd HH:mm:ss' }}</td>
         <!--<td><input class="col-xs-2" id="variableValue" type="checkbox" ng-model="vm.selected.hasInsights" placeholder="value"></td>-->
         <td>
             <div ng-switch on="vm.selected.type">

--- a/settings/variableController.js
+++ b/settings/variableController.js
@@ -125,12 +125,5 @@ angular.module('CountDownApp', ['smart-table'])
     });
 
 function getShortDate() {
-    now = new Date();
-    year = "" + now.getFullYear();
-    month = "" + (now.getMonth() + 1); if (month.length == 1) { month = "0" + month; }
-    day = "" + now.getDate(); if (day.length == 1) { day = "0" + day; }
-    hour = "" + now.getHours(); if (hour.length == 1) { hour = "0" + hour; }
-    minute = "" + now.getMinutes(); if (minute.length == 1) { minute = "0" + minute; }
-    second = "" + now.getSeconds(); if (second.length == 1) { second = "0" + second; }
-    return year + "-" + month + "-" + day + " " + hour + ":" + minute + ":" + second;
+    return new Date().toISOString();
 }


### PR DESCRIPTION
Fix the last action date in the countdown grid and have it show a human readable format in sync with the users timezone. The fix is based on a commit from the BetterLogic app: https://github.com/PatrickSannes/BetterLogic/commit/3b36e9f24c344e98ea9670c0648c882ade356015